### PR TITLE
pick a better invalid hostname

### DIFF
--- a/test/invoke.policy.http.test.js
+++ b/test/invoke.policy.http.test.js
@@ -53,7 +53,10 @@ describe('invokePolicy', function() {
       .then(function() { return microgw.stop(); })
       .then(function() { return backend.stop(); })
       .then(done, done)
-      .catch(done);
+      .catch(function(err) {
+        console.log(err);
+        done(err);
+      });
   });
 
   var data = { msg: 'Hello world' };
@@ -174,7 +177,7 @@ describe('invokePolicy', function() {
 
     request
       .get('/invoke/dynHost')
-      .set('X-TEST-HOSTNAME', 'cannot.be.valid.com')
+      .set('X-TEST-HOSTNAME', 'cannotbevalidcom')
       .expect(function(res, done) {
         if (res.res.statusCode !== 500) {
           throw new Error('status code should be 500');
@@ -184,7 +187,7 @@ describe('invokePolicy', function() {
         }
       })
       .expect(/"name":"ConnectionError"/)
-      .expect(/getaddrinfo ENOTFOUND cannot.be.valid.com/,
+      .expect(/getaddrinfo ENOTFOUND cannotbevalidcom/,
               done);
   });
 


### PR DESCRIPTION
Pick a better invalid hostname that wont tickle the DNS
resolver to perform a ndots search, resulting in a timeout
vs hostname lookup error.