### PR TITLE
Issues with Dockerizing nginx with microgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ cd $HOME/microgateway
 npm install
 ```
 
-Step 3. Change current working directory to the test directory
+Step 3. Change current working directory to the root directory
 ```
-cd $HOME/microgateway/test
+cd $HOME/microgateway/
 ```
 
 Step 4. Create a startup script that sets environment variables and starts up
 the Microgateway. The script file is a simple node.js JavaScript file shown
-below. Create this file in the `$HOME/microgateway/test` directory.
+below. Create this file in the `$HOME/microgateway/` directory.
 
 Note:  The CONFIG_DIR is the folder containing the yaml files holding the API
 definitions that you wish to enforce.
@@ -192,7 +192,7 @@ var mg = require('../lib/microgw');
 var fs = require('fs');
 
 // config dir
-process.env.CONFIG_DIR = __dirname + '/definitions/sample';
+process.env.CONFIG_DIR = __dirname + '/definitions/myapp';
 process.env.NODE_ENV = 'production';
 mg.start(3000);
 ```
@@ -200,7 +200,7 @@ mg.start(3000);
 Step 4. Create a yaml file to define the API. Place the yaml file in the folder
 identified by the `CONFIG_DIR` environment variable created in the startup script.
 For this example, we are creating the file sample_1.0.0.yaml in the
-`$HOME/microgateway/test/definitions/sample` directory. Note that you can place
+`$HOME/microgateway/definitions/myapp` directory. Note that you can place
 several yaml files in this directory and all will be pulled in and used by the
 Microgateway.
 ```
@@ -229,9 +229,9 @@ schemes:
   - http
 ```
 
-Step 5. From the test directory, execute the command to start the Microgateway.
+Step 5. From the root directory, execute the command to start the Microgateway.
 ```
-cd $HOME/microgateway/test
+cd $HOME/microgateway/
 node sample.js
 ```
 
@@ -241,7 +241,7 @@ Step 6. Send a curl command to test the API. It should return the
 curl http://localhost:3000/sample/echo
 ```
 
-For more information on the internal specifics of the Microgatewayy, you may
+For more information on the internal specifics of the Microgateway, you may
 want to look at the microgateway/test directory. All middleware components
 have one or more test suites to exercise their interfaces and logic.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
   nginx:
     build: nginx
     environment:
-      - GATEWAY_DNS=microgateway
+      - GATEWAY_DNS=microgateway:80
     ports:
       - "443:443"
     container_name: nginx

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -5,4 +5,7 @@ ADD run.sh /
 
 RUN chmod +x /run.sh
 
+RUN apt-get update; apt-get install -y \
+    openssl
+	
 CMD /run.sh

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -22,7 +22,7 @@ http {
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
 
-      proxy_pass          http://GATEWAY:80;
+      proxy_pass          http://GATEWAY;
       proxy_read_timeout  60;
     }
   }


### PR DESCRIPTION
-Avoid hardcoding port numbers in ngnix file since they should be
obtained via docker
-Modified the README.md file to deploy the microgateway starter script
in the root directory instead of the test directory. Its easier to run
the microgateway via docker from a known location in the root directory
vs previous test directory
-Added openssl to the ngnix Dockerfile since its needed as part of the
Docker build